### PR TITLE
Fix bindgen by adding size_t_is_usize, address deprecation warnings

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -110,7 +110,7 @@ fn bindgen_rocksdb(rocksdb_lib_info: Option<pkg_config::Library>) {
             builder.clang_arg(format!("-I{}", include_path))
         })
         .header("rocksdb/include/rocksdb/c.h")
-        .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
+        .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
         .size_t_is_usize(true)
         .generate()

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -112,6 +112,7 @@ fn bindgen_rocksdb(rocksdb_lib_info: Option<pkg_config::Library>) {
         .header("rocksdb/include/rocksdb/c.h")
         .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
+        .size_t_is_usize(true)
         .generate()
         .expect("unable to generate rocksdb bindings");
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -17,7 +17,7 @@
 use {DB, Error};
 use ffi;
 
-use libc::{c_int, uint32_t};
+use libc::c_int;
 use std::ffi::CString;
 use std::path::Path;
 
@@ -76,7 +76,7 @@ impl BackupEngine {
         unsafe {
             ffi_try!(ffi::rocksdb_backup_engine_purge_old_backups(
                 self.inner,
-                num_backups_to_keep as uint32_t,
+                num_backups_to_keep as u32,
             ));
             Ok(())
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -452,7 +452,7 @@ impl DBIterator {
         mode: IteratorMode,
     ) -> Result<DBIterator, Error> {
         let mut rv = DBIterator {
-            raw: try!(DBRawIterator::new_cf(db, cf_handle, readopts)),
+            raw: DBRawIterator::new_cf(db, cf_handle, readopts)?,
             direction: Direction::Forward, // blown away by set_mode()
             just_seeked: false,
         };

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -16,7 +16,7 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::path::Path;
 
-use libc::{self, c_int, c_uchar, c_uint, c_void, size_t, uint64_t};
+use libc::{self, c_int, c_uchar, c_uint, c_void, size_t};
 
 use ffi;
 use {BlockBasedOptions, BlockBasedIndexType, DBCompactionStyle, DBCompressionType, DBRecoveryMode, MemtableFactory,
@@ -151,7 +151,7 @@ impl Options {
         unsafe {
             ffi::rocksdb_options_optimize_level_style_compaction(
                 self.inner,
-                memtable_memory_budget as uint64_t,
+                memtable_memory_budget as u64,
             );
         }
     }


### PR DESCRIPTION
I made sure that the tests pass this time 🤦🏽 

```bash
agreen @ tuan-lappy ~/repo/rust-rocksdb (agreen/fix-bindgen)
└─ $ ▶ cargo test --all-features
.
.
test src/lib.rs - WriteOptions (line 208) ... ok
test src/merge_operator.rs - merge_operator (line 18) ... ok
test src/refactor/common.rs - refactor::common::RawDatabaseIterator::seek (line 441) ... ok
test src/refactor/common.rs - refactor::common::RawDatabaseIterator::seek_for_prev (line 475) ... ok
test src/refactor/common.rs - refactor::common::RawDatabaseIterator::seek_to_first (line 366) ... ok
test src/refactor/database.rs - refactor::database::Options::wal_recovery_mode (line 276) ... ok
test src/refactor/common.rs - refactor::common::RawDatabaseIterator::seek_to_last (line 402) ... ok

test result: ok. 55 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

I am able to successfully build `major-tom` with these changes:

```bash
agreen @ tuan-lappy ~/repo/major-tom/major-tom (agreen/update-grpcio-decibel-rs-and-major-tom-proto-deps)
└─ $ ▶ grep rocks Cargo.toml -A 2
[dependencies.rocksdb]
git = "ssh://git@github.com/StarryInternet/rust-rocksdb.git"
branch = "agreen/fix-bindgen"
default-features = false
agreen @ tuan-lappy ~/repo/major-tom/major-tom (agreen/update-grpcio-decibel-rs-and-major-tom-proto-deps)
└─ $ ▶ cargo update
    Updating crates.io index
    Updating git repository `ssh://git@github.com/ProjectDecibel/decibel-rs.git`
    Updating git repository `ssh://git@github.com/ProjectDecibel/major-tom.git`
    Updating git repository `ssh://git@github.com/StarryInternet/rust-rocksdb.git`
agreen @ tuan-lappy ~/repo/major-tom/major-tom (agreen/update-grpcio-decibel-rs-and-major-tom-proto-deps)
└─ $ ▶ cargo build
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
```